### PR TITLE
Refactor StateMachineInputs as DependencyObjects

### DIFF
--- a/RiveSharp.Views.UWP/RiveSharp.Views.UWP.csproj
+++ b/RiveSharp.Views.UWP/RiveSharp.Views.UWP.csproj
@@ -123,6 +123,7 @@
     <Compile Include="RivePlayer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StateMachineInput.cs" />
+    <Compile Include="StateMachineInputCollection.cs" />
     <EmbeddedResource Include="Properties\RiveSharp.Views.UWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/RiveSharp.Views.UWP/StateMachineInputCollection.cs
+++ b/RiveSharp.Views.UWP/StateMachineInputCollection.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+
+namespace RiveSharp.Views
+{
+    // Manages a collection of StateMachineInput objects for RivePlayer. The [ContentProperty] tag
+    // on RivePlayer instructs the XAML engine automatically route nested inputs through this
+    // collection:
+    //
+    //   <rive:RivePlayer Source="...">
+    //       <rive:BoolInput Target=... />
+    //   </rive:RivePlayer>
+    //
+    public class StateMachineInputCollection : DependencyObjectCollection
+    {
+        private WeakReference<RivePlayer> mRivePlayer;
+
+        public StateMachineInputCollection(RivePlayer rivePlayer)
+        {
+            mRivePlayer = new WeakReference<RivePlayer>(rivePlayer);
+            VectorChanged += InputsVectorChanged;
+        }
+
+        private void InputsVectorChanged(IObservableVector<DependencyObject> sender,
+                                         IVectorChangedEventArgs @event)
+        {
+            switch (@event.CollectionChange)
+            {
+                case CollectionChange.ItemInserted:
+                case CollectionChange.ItemChanged:
+                    {
+                        var input = (StateMachineInput)sender[(int)@event.Index];
+                        input.SetRivePlayer(mRivePlayer);
+                    }
+                    break;
+                case CollectionChange.ItemRemoved:
+                    {
+                        var input = (StateMachineInput)sender[(int)@event.Index];
+                        input.SetRivePlayer(new WeakReference<RivePlayer>(null));
+                        break;
+                    }
+                case CollectionChange.Reset:
+                    foreach (StateMachineInput input in sender)
+                    {
+                        input.SetRivePlayer(new WeakReference<RivePlayer>(null));
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/samples/StateMachineInputs/MainPage.xaml
+++ b/samples/StateMachineInputs/MainPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="StateMachineInputs.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -15,11 +15,11 @@
             <ColumnDefinition Width="400" />
         </Grid.ColumnDefinitions>
         <rive:RivePlayer DrawInBackground="True" Source="https://public.rive.app/community/runtime-files/2244-4463-animated-login-screen.riv" Grid.Column="0">
-            <rive:StateMachineInputBool rive:InputName="isChecking" Value="{Binding IsChecked, ElementName=IsChecking}" />
-            <rive:StateMachineInputNumber rive:InputName="numLook" Value="{Binding Value, ElementName=NumLook}" />
-            <rive:StateMachineInputBool rive:InputName="isHandsUp" Value="{Binding IsChecked, ElementName=IsHandsUp}" />
-            <rive:StateMachineInputTrigger rive:InputName="trigFail" x:Name="TrigFail" />
-            <rive:StateMachineInputTrigger rive:InputName="trigSuccess" x:Name="TrigSuccess" />
+            <rive:BoolInput Target="isChecking" Value="{Binding IsChecked, ElementName=IsChecking}" />
+            <rive:NumberInput Target="numLook" Value="{Binding Value, ElementName=NumLook}" />
+            <rive:BoolInput Target="isHandsUp" Value="{Binding IsChecked, ElementName=IsHandsUp}" />
+            <rive:TriggerInput Target="trigFail" x:Name="TrigFail" />
+            <rive:TriggerInput Target="trigSuccess" x:Name="TrigSuccess" />
         </rive:RivePlayer>
         <StackPanel VerticalAlignment="Center" Padding="20" Spacing="10" Grid.Column="1">
             <CheckBox Content="Looking" x:Name="IsChecking" />

--- a/samples/StateMachineInputs/Properties/AssemblyInfo.cs
+++ b/samples/StateMachineInputs/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("StateMachineInputs")]
+[assembly: AssemblyTitle("StateMachineInputCollection")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Rive")]
-[assembly: AssemblyProduct("StateMachineInputs")]
+[assembly: AssemblyProduct("StateMachineInputCollection")]
 [assembly: AssemblyCopyright("Copyright © Rive 2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
State machine inputs are not UI elements to layout, so we should use
[ContentAttribute] instead to implement them as light-weight
DependencyObjects.